### PR TITLE
Fix mobile layout issues in core expertise section

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1980,7 +1980,7 @@ main {
   }
 
   .skills-grid {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(2, 1fr);
     gap: 1rem;
   }
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -2077,6 +2077,10 @@ main {
     grid-template-columns: 1fr;
   }
 
+  .skills-grid {
+    grid-template-columns: 1fr;
+  }
+
   .heatmap-grid {
     grid-template-columns: repeat(2, 1fr);
   }

--- a/assets/style.css
+++ b/assets/style.css
@@ -118,7 +118,7 @@ body::before {
 
 .featured-skills .container {
   margin: 0 auto 25px;
-  padding: 0 1rem 35px 59px;
+  padding: 0 1rem 35px;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Purpose
Fix layout issues in the core expertise section that were causing display problems on mobile devices. The user reported that the expertise section was not rendering properly in mobile view and needed resolution.

## Code changes
- Removed excessive left padding (59px) from `.featured-skills .container` to prevent horizontal overflow
- Adjusted skills grid layout for better mobile responsiveness:
  - Changed from 4 columns to 2 columns on medium screens
  - Added single column layout for small mobile screens
- Improved overall mobile layout consistency for the expertise/skills section

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b075826276734880bedf61af0aecdee0/stellar-garden)

👀 [Preview Link](https://b075826276734880bedf61af0aecdee0-stellar-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b075826276734880bedf61af0aecdee0</projectId>-->
<!--<branchName>stellar-garden</branchName>-->